### PR TITLE
Incorrect mask

### DIFF
--- a/example/echo.c
+++ b/example/echo.c
@@ -14,7 +14,7 @@ void writeToClient(aeEventLoop *loop, int fd, void *clientdata, int mask)
     printf("%p\n", clientdata);
     write(fd, buffer, strlen(buffer));
     free(buffer);
-    aeDeleteFileEvent(loop, fd, AE_WRITABLE);
+    aeDeleteFileEvent(loop, fd, mask);
 }
 
 void readFromClient(aeEventLoop *loop, int fd, void *clientdata, int mask)


### PR DESCRIPTION
Incorrect mask is applied to aeDeleteFileEvent inside writeToClient, which causes the server to get into endless loop and crash after client closed the connection.